### PR TITLE
name is special - use migration name

### DIFF
--- a/lib/generators/templates/migration.rb
+++ b/lib/generators/templates/migration.rb
@@ -10,7 +10,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
     author_slack_handle "<%= ENV['MIGRATION_SLACK_HANDLE'] %>" # Don't forget the '@' in front
     failure_consequences nil # Allows author to explain what could go wrong if this data migration fails.
     failure_runbook nil # Can be used for the author to explain what steps to take to fix the issue on potential failure scenarios.
-    name "<%= migration_class_name %>"
+    migration_name "<%= migration_class_name %>"
   end
 
   # Define common queries that you will be using for printing start information, running the migration itself

--- a/lib/nondestructive_migrations/nondestructive_migration.rb
+++ b/lib/nondestructive_migrations/nondestructive_migration.rb
@@ -34,8 +34,8 @@ module DataMigrations
         @migration_information[:run_strategy] = val
       end
 
-      def name(val)
-        @migration_information[:name] = val
+      def migration_name(val)
+        @migration_information[:migration_name] = val
       end
     end
 
@@ -65,6 +65,7 @@ module DataMigrations
           slack_handle: self.class.migration_information[:author_slack_handle],
           failure_consequences: self.class.migration_information[:failure_consequences],
           failure_runbook: self.class.migration_information[:failure_runbook],
+          migration_name: self.class.migration_information[:migration_name],
         }
       )
 
@@ -120,7 +121,7 @@ module DataMigrations
     end
 
     def webhook_success_text
-      "*Successfully ran* migration #{self.class.migration_information[:name]} in #{Rails.env}."
+      "*Successfully ran* migration #{self.class.migration_information[:migration_name]} in #{Rails.env}."
     end
 
     def webhook_fail_hash(exception, channel)
@@ -133,7 +134,7 @@ module DataMigrations
     end
 
     def webhook_fail_text(exception)
-      rv = "*Failed to run* (#{self.class.migration_information[:author_email]}) #{self.class.migration_information[:author_slack_handle]}'s migration #{self.class.migration_information[:name]} in #{Rails.env}.\n"
+      rv = "*Failed to run* (#{self.class.migration_information[:author_email]}) #{self.class.migration_information[:author_slack_handle]}'s migration #{self.class.migration_information[:migration_name]} in #{Rails.env}.\n"
       rv += "*Consequences*: #{self.class.migration_information[:failure_consequences]}.\n*Runbook*: #{self.class.migration_information[:failure_runbook]}.\n"
       rv += "```#{exception.message}\n#{exception.backtrace.first(10)}...```"
       rv


### PR DESCRIPTION
defining name on a class is a bad idea as its a reserved method name - change this to migration_name
