### PR TITLE
Update nondestructive-migrations.gemspec

### DIFF
--- a/nondestructive-migrations.gemspec
+++ b/nondestructive-migrations.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'minitest'
   s.add_runtime_dependency 'activerecord'
+  s.add_runtime_dependency 'valid_email'
 end


### PR DESCRIPTION
This fork requires the `valid_email` gem to work. `ValidateEmail` is undefined otherwise. This hasn't come up in the handshake main app because that app has the `valid_email` gem as an explicit dependency.
