### PR TITLE
Update nondestructive_migration.rb

### DIFF
--- a/lib/nondestructive_migrations/nondestructive_migration.rb
+++ b/lib/nondestructive_migrations/nondestructive_migration.rb
@@ -3,6 +3,7 @@ module DataMigrations
     require "net/http"
     require "uri"
     require "json"
+    require "valid_email/validate_email"
 
     module ClassMethods
       def migration_information


### PR DESCRIPTION
Needed to require it explicitly here as well. Having it in the top level gemfile did that for us but it doesn't get auto-loaded when it's only a gem-level dependency.
