### PR TITLE
add link names for slack webhook

### DIFF
--- a/lib/nondestructive_migrations/nondestructive_migration.rb
+++ b/lib/nondestructive_migrations/nondestructive_migration.rb
@@ -130,7 +130,8 @@ module DataMigrations
         channel: channel || default_slack_channel,
         username: slack_username,
         icon_emoji: slack_emoji,
-        text: webhook_fail_text(exception)
+        text: webhook_fail_text(exception),
+        link_names: 1
       }
     end
 


### PR DESCRIPTION
https://api.slack.com/docs/formatting

> By default, Slack will not linkify channel names (starting with a '#') and usernames (starting with an '@'). You can enable this behavior by passing link_names=1 as an argument. This behavior is always enabled in parse=full mode (see below).
