### PR TITLE
Only print the text, not the hash

### DIFF
--- a/lib/nondestructive_migrations/nondestructive_migration.rb
+++ b/lib/nondestructive_migrations/nondestructive_migration.rb
@@ -48,7 +48,7 @@ module DataMigrations
 
     def up
       if Rails.env.development?
-        puts webhook_start_hash(nil)
+        puts webhook_start_hash(nil)[:text]
       else
         send_slack_webhook(webhook_start_hash(nil))
         send_slack_webhook(webhook_start_hash(self.class.migration_information[:author_slack_handle]))


### PR DESCRIPTION
When I ran a dummy migration locally, I noticed it was printing the entire hash instead of just the message, which is done for other messages.

<img width="1122" alt="Screen Shot 2019-05-24 at 12 03 50 PM" src="https://user-images.githubusercontent.com/7925902/58344711-118abd80-7e1c-11e9-9f8b-489b3ede2688.png">
